### PR TITLE
Upgrade for new requests version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ from setuptools import setup
 LONG_DESCRIPTION_MD = __doc__
 LONG_DESCRIPTION = re.sub(r'(?s)\[(.*?)\]\((http.*?)\)', r'\1', LONG_DESCRIPTION_MD)
 
-INSTALL_REQUIRES = ["setuptools", "idna", "requests>=2.1.0", "requests-file>=1.4"]
+INSTALL_REQUIRES = ["setuptools", "idna", "requests>=2.1.0", "requests-file>=1.4", "certifi>=2018.1.18"]
 if (2, 7) > sys.version_info:
     INSTALL_REQUIRES.append("argparse>=1.2.1")
 

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -34,7 +34,11 @@ def find_first_response(urls, cache_fetch_timeout=None):
 
         for url in urls:
             try:
-                text = session.get(url, timeout=cache_fetch_timeout, verify=resource_filename('certifi', 'cacert.pem')).text
+                text = session.get(
+                    url,
+                    timeout=cache_fetch_timeout,
+                    verify=resource_filename('certifi', 'cacert.pem')
+                ).text
             except requests.exceptions.RequestException:
                 LOG.exception(
                     'Exception reading Public Suffix List url %s',

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -7,6 +7,7 @@ import socket
 import sys
 
 import requests
+from pkg_resources import resource_filename
 from requests_file import FileAdapter
 
 # pylint: disable=import-error,invalid-name,no-name-in-module,redefined-builtin
@@ -33,7 +34,7 @@ def find_first_response(urls, cache_fetch_timeout=None):
 
         for url in urls:
             try:
-                text = session.get(url, timeout=cache_fetch_timeout).text
+                text = session.get(url, timeout=cache_fetch_timeout, verify=resource_filename('certifi', 'cacert.pem')).text
             except requests.exceptions.RequestException:
                 LOG.exception(
                     'Exception reading Public Suffix List url %s',


### PR DESCRIPTION
Ref: https://github.com/john-kurkowski/tldextract/pull/145
Merging ^ here in my master to be able to use it until ^ gets merged and versioned.

This PR intends to provide the ability to the session to find the `cacert.pem` file required by `requests`. It makes `find_first_response` work in the case when `tldextract`, `requests`, `certifi` are all bundled in one `.egg`/`.zip` file and the code is run from that bundle leading to this error -

```
File "./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/tldextract/tldextract.py", line 329, in extract
    return TLD_EXTRACTOR(url)
  File "./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/tldextract/tldextract.py", line 209, in __call__
    suffix_index = self._get_tld_extractor().suffix_index(translations)
  File "./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/tldextract/tldextract.py", line 249, in _get_tld_extractor
    raw_suffix_list_data = find_first_response(self.suffix_list_urls)
  File "./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/tldextract/remote.py", line 38, in find_first_response
    text = session.get(url).text
  File "./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/requests/sessions.py", line 521, in get
    return self.request('GET', url, **kwargs)
  File "./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/requests/sessions.py", line 508, in request
    resp = self.send(prep, **send_kwargs)
  File "./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/requests/sessions.py", line 618, in send
    r = adapter.send(request, **kwargs)
  File "./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/requests/adapters.py", line 407, in send
    self.cert_verify(conn, request.url, verify, cert)
  File "./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/requests/adapters.py", line 226, in cert_verify
    "invalid path: {0}".format(cert_loc))
IOError: Could not find a suitable TLS CA certificate bundle, invalid path: ./packages-e79cd9628c5bca67379a4f131d342e8420480100.egg/certifi/cacert.pem
```

